### PR TITLE
Fixed data-type bugs; new records to rescale positions

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -21,10 +21,10 @@
 
 TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
 
-SUPPORT=/usr/local/epics/synApps_5_8/support
+SUPPORT=/usr/local/epics/synApps_6_1/support
 
-ASYN= $(SUPPORT)/asyn-4-26
-GENSUB= $(SUPPORT)/genSubV1-8
+ASYN= $(SUPPORT)/asyn-R4-36
+#GENSUB= $(SUPPORT)/genSubV1-8
 
 # If using the sequencer, point SNCSEQ at its top directory:
 #SNCSEQ=$(EPICS_BASE)/../modules/soft/seq

--- a/picoScaleApp/Db/picoScale_Channel_Common.db
+++ b/picoScaleApp/Db/picoScale_Channel_Common.db
@@ -4,8 +4,19 @@ record(longin, "$(C):$(P):POS_$(Ch)"){
     field(DESC, "Position $(Ch)")
     field(DTYP, "asynInt32")
     field(SCAN, "I/O Intr")
-    field(EGU, "nm")
+    field(EGU, "pm")
     field(INP, "@asyn($(PORTNAME),$(ADDRESS),$(TIMEOUT))POS_CH$(Ch)_LONGIN_VAL")
+}
+
+record(longout, "$(C):$(P):SCALEPOS_$(Ch)"){
+    field(DESC, "Position $(Ch) rescaling")
+    field(DTYP, "asynInt32")
+    field(VAL, "1")
+    field(EGU, "1/pm")
+    field(HOPR, "1000")
+    field(LOPR, "1")
+    field(PINI, "YES")
+    field(OUT, "@asyn($(PORTNAME),$(ADDRESS),$(TIMEOUT))SCALEPOS_CH$(Ch)_LONGOUT_VAL")
 }
 
 record(longin, "$(C):$(P):VEL_$(Ch)"){

--- a/picoScaleApp/src/Makefile
+++ b/picoScaleApp/src/Makefile
@@ -7,6 +7,7 @@ include $(TOP)/configure/CONFIG
 PROD_IOC = picoScale
 
 #picoScale_CXXFLAGS = -L/home/ABTLUS/allan.bugyi/work/dev/iocs/SMARACT_PICOSCALE_IOC/src/
+
 picoScale_SYS_LIBS += ftchipid
 picoScale_SYS_LIBS += ftd2xx
 picoScale_SYS_LIBS += smaractio
@@ -30,7 +31,7 @@ picoScale_DBD += base.dbd
 picoScale_DBD += asyn.dbd
 picoScale_DBD += picoScale_functions.dbd
 
-picoScale_LIBS += asyn genSub
+picoScale_LIBS += asyn
 
 # picoScale_registerRecordDeviceDriver.cpp derives from picoScale.dbd
 picoScale_SRCS += picoScaledrv.cpp

--- a/picoScaleApp/src/picoScaledrv.cpp
+++ b/picoScaleApp/src/picoScaledrv.cpp
@@ -440,37 +440,37 @@ void PicoScaledrv::picoScale_dataSourcesValues_EPICSRecordsWriting(void *pValue,
                 case 3:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swraw_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swraw_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 4:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wraw_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wraw_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 5:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(sw_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(sw_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 6:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2w_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2w_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 7:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swquality_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swquality_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 8:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wquality_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wquality_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 /*case 9:
@@ -485,19 +485,19 @@ void PicoScaledrv::picoScale_dataSourcesValues_EPICSRecordsWriting(void *pValue,
                 break;*/
                 case 11:
                     v.i64value = *(const int64_t*)(pValue);
-                    aux_float64_t_prop = static_cast<float>(v.f64value);
+                    aux_int64_t_prop = static_cast<int>(v.i64value);
                     setIntegerParam(envtemp_ch0_longInValue, aux_int64_t_prop); 
                     callParamCallbacks();                    
                 break;
                 case 12:
                     v.i64value = *(const int64_t*)(pValue);
-                    aux_float64_t_prop = static_cast<float>(v.f64value);
+                    aux_int64_t_prop = static_cast<int>(v.i64value);
                     setIntegerParam(envHum_ch0_longInValue, aux_int64_t_prop); 
                     callParamCallbacks();                            
                 break;
                 case 13:
                     v.i64value = *(const int64_t*)(pValue);
-                    aux_float64_t_prop = static_cast<float>(v.f64value);
+                    aux_int64_t_prop = static_cast<int>(v.i64value);
                     setIntegerParam(envPress_ch0_longInValue, aux_int64_t_prop); 
                     callParamCallbacks();                            
                 break;                
@@ -526,37 +526,37 @@ void PicoScaledrv::picoScale_dataSourcesValues_EPICSRecordsWriting(void *pValue,
                 case 3:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swraw_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swraw_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 4:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wraw_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wraw_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 5:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(sw_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(sw_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 6:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2w_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2w_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 7:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swquality_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swquality_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 8:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wquality_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wquality_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;                
             }
@@ -584,37 +584,37 @@ void PicoScaledrv::picoScale_dataSourcesValues_EPICSRecordsWriting(void *pValue,
                 case 3:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swraw_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swraw_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 4:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wraw_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wraw_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 5:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(sw_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(sw_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 6:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2w_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2w_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 7:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swquality_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swquality_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 8:
                     v.f64value = *(const double*)(pValue);
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wquality_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wquality_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;                
             }
@@ -1135,32 +1135,32 @@ void PicoScaledrv::picoScale_poll(){
                 break;
                 case 3:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swraw_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swraw_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 4:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wraw_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wraw_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 5:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(sw_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(sw_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 6:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2w_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2w_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 7:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swquality_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swquality_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 8:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wquality_ch0_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wquality_ch0_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 /*case 9:
@@ -1174,17 +1174,17 @@ void PicoScaledrv::picoScale_poll(){
                     callParamCallbacks(); 
                 break;*/
                 case 11:
-                    aux_float64_t_prop = static_cast<float>(v.f64value);
+                    aux_int64_t_prop = static_cast<int>(v.i64value);
                     setIntegerParam(envtemp_ch0_longInValue, aux_int64_t_prop); 
                     callParamCallbacks();                    
                 break;
                 case 12:
-                    aux_float64_t_prop = static_cast<float>(v.f64value);
+                    aux_int64_t_prop = static_cast<int>(v.i64value);
                     setIntegerParam(envHum_ch0_longInValue, aux_int64_t_prop); 
                     callParamCallbacks();                            
                 break;
                 case 13:
-                    aux_float64_t_prop = static_cast<float>(v.f64value);
+                    aux_int64_t_prop = static_cast<int>(v.i64value);
                     setIntegerParam(envPress_ch0_longInValue, aux_int64_t_prop); 
                     callParamCallbacks();                            
                 break;
@@ -1209,32 +1209,32 @@ void PicoScaledrv::picoScale_poll(){
                 break;
                 case 3:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swraw_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swraw_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 4:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wraw_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wraw_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 5:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(sw_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(sw_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 6:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2w_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2w_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 7:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swquality_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swquality_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 8:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wquality_ch1_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wquality_ch1_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
             }
@@ -1258,32 +1258,32 @@ void PicoScaledrv::picoScale_poll(){
                 break;
                 case 3:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swraw_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swraw_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 4:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wraw_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wraw_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 5:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(sw_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(sw_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 6:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2w_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2w_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 7:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(swquality_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(swquality_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
                 case 8:
                     aux_float64_t_prop = static_cast<float>(v.f64value);
-                    setDoubleParam(s2wquality_ch2_analogInValue, aux_int64_t_prop); 
+                    setDoubleParam(s2wquality_ch2_analogInValue, aux_float64_t_prop); 
                     callParamCallbacks(); 
                 break;
             }

--- a/picoScaleApp/src/picoScaledrv.cpp
+++ b/picoScaleApp/src/picoScaledrv.cpp
@@ -56,6 +56,7 @@ PicoScaledrv::PicoScaledrv(const char *portName, const char *ip)
 	0, 0) /* Default priority and stack size */
 {
 	createParam(pos_ch0_longInValueString, asynParamInt32, &pos_ch0_longInValue);
+	createParam(scalepos_ch0_longOutValueString, asynParamInt32, &scalepos_ch0_longOutValue);
 	createParam(vel_ch0_longInValueString, asynParamInt32, &vel_ch0_longInValue);
 	createParam(acc_ch0_longInValueString, asynParamInt32, &acc_ch0_longInValue);
 	createParam(swraw_ch0_analogInValueString, asynParamFloat64, &swraw_ch0_analogInValue);
@@ -81,6 +82,7 @@ PicoScaledrv::PicoScaledrv(const char *portName, const char *ip)
 	createParam(calcSys6_ch0_longInValueString, asynParamInt32, &calcSys6_ch0_longInValue);
 	createParam(calcSys7_ch0_longInValueString, asynParamInt32, &calcSys7_ch0_longInValue);*/
 	createParam(pos_ch1_longInValueString, asynParamInt32, &pos_ch1_longInValue);
+	createParam(scalepos_ch1_longOutValueString, asynParamInt32, &scalepos_ch1_longOutValue);
 	createParam(vel_ch1_longInValueString, asynParamInt32, &vel_ch1_longInValue);
 	createParam(acc_ch1_longInValueString, asynParamInt32, &acc_ch1_longInValue);
 	createParam(swraw_ch1_analogInValueString, asynParamFloat64, &swraw_ch1_analogInValue);
@@ -90,6 +92,7 @@ PicoScaledrv::PicoScaledrv(const char *portName, const char *ip)
 	createParam(swquality_ch1_analogInValueString, asynParamFloat64, &swquality_ch1_analogInValue);
 	createParam(s2wquality_ch1_analogInValueString, asynParamFloat64, &s2wquality_ch1_analogInValue);
 	createParam(pos_ch2_longInValueString, asynParamInt32, &pos_ch2_longInValue);
+	createParam(scalepos_ch2_longOutValueString, asynParamInt32, &scalepos_ch2_longOutValue);
 	createParam(vel_ch2_longInValueString, asynParamInt32, &vel_ch2_longInValue);
 	createParam(acc_ch2_longInValueString, asynParamInt32, &acc_ch2_longInValue);
 	createParam(swraw_ch2_analogInValueString, asynParamFloat64, &swraw_ch2_analogInValue);
@@ -413,8 +416,13 @@ unsigned int PicoScaledrv::configureStream(SA_SI_Handle handle){
 //Registering the data source(s) streamed values on records
 void PicoScaledrv::picoScale_dataSourcesValues_EPICSRecordsWriting(void *pValue, size_t dataSourceIndex){
     int aux_int64_t_prop;
+    int scalePos0, scalePos1, scalePos2;
     float aux_float64_t_prop;
     VariantValue v;
+
+    getIntegerParam(scalepos_ch0_longOutValue, &scalePos0);
+    getIntegerParam(scalepos_ch1_longOutValue, &scalePos1);
+    getIntegerParam(scalepos_ch2_longOutValue, &scalePos2);
     
     switch(streamConfig.enabledDataSources[dataSourceIndex].address.channelIndex){
         case 0:
@@ -422,7 +430,7 @@ void PicoScaledrv::picoScale_dataSourcesValues_EPICSRecordsWriting(void *pValue,
                 case 0:
                     v.i64value = *(const int64_t*)(pValue);
                     aux_int64_t_prop = static_cast<int>(v.i48value);
-                    setIntegerParam(pos_ch0_longInValue, aux_int64_t_prop); 
+                    setIntegerParam(pos_ch0_longInValue, aux_int64_t_prop / scalePos0); 
                     callParamCallbacks();
                 break;
                 case 1:
@@ -508,7 +516,7 @@ void PicoScaledrv::picoScale_dataSourcesValues_EPICSRecordsWriting(void *pValue,
                 case 0:
                     v.i64value = *(const int64_t*)(pValue);
                     aux_int64_t_prop = static_cast<int>(v.i48value);
-                    setIntegerParam(pos_ch1_longInValue, aux_int64_t_prop); 
+                    setIntegerParam(pos_ch1_longInValue, aux_int64_t_prop / scalePos1); 
                     callParamCallbacks();
                 break;
                 case 1:
@@ -566,7 +574,7 @@ void PicoScaledrv::picoScale_dataSourcesValues_EPICSRecordsWriting(void *pValue,
                 case 0:
                     v.i64value = *(const int64_t*)(pValue);
                     aux_int64_t_prop = static_cast<int>(v.i48value);
-                    setIntegerParam(pos_ch2_longInValue, aux_int64_t_prop); 
+                    setIntegerParam(pos_ch2_longInValue, aux_int64_t_prop / scalePos2); 
                     callParamCallbacks();
                 break;
                 case 1:
@@ -1076,11 +1084,15 @@ void PicoScaledrv::picoScale_streamPosition_allChannels(){
 
 void PicoScaledrv::picoScale_poll(){
     int channelIndex, datasrcIndex, aux_int64_t_prop;
+    int scalePos0, scalePos1, scalePos2;
     float aux_float64_t_prop;
     int32_t dataType;
     VariantValue v;
     getIntegerParam(channelindx_mbboValue, &channelIndex);
     getIntegerParam(datasrcindx_mbboValue, &datasrcIndex);
+    getIntegerParam(scalepos_ch0_longOutValue, &scalePos0);
+    getIntegerParam(scalepos_ch1_longOutValue, &scalePos1);
+    getIntegerParam(scalepos_ch2_longOutValue, &scalePos2);
     
     result = SA_SI_GetProperty_i32(handle, SA_SI_EPK(SA_SI_DATA_TYPE_PROP, channelIndex, datasrcIndex),&dataType,0); 
     
@@ -1120,7 +1132,7 @@ void PicoScaledrv::picoScale_poll(){
             switch(datasrcIndex){
                 case 0:
                     aux_int64_t_prop = static_cast<int>(v.i64value);
-                    setIntegerParam(pos_ch0_longInValue, aux_int64_t_prop); 
+                    setIntegerParam(pos_ch0_longInValue, aux_int64_t_prop / scalePos0); 
                     callParamCallbacks();
                 break;
                 case 1:
@@ -1194,7 +1206,7 @@ void PicoScaledrv::picoScale_poll(){
             switch(datasrcIndex){
                 case 0:
                     aux_int64_t_prop = static_cast<int>(v.i64value);
-                    setIntegerParam(pos_ch1_longInValue, aux_int64_t_prop); 
+                    setIntegerParam(pos_ch1_longInValue, aux_int64_t_prop / scalePos1); 
                     callParamCallbacks();
                 break;
                 case 1:
@@ -1243,7 +1255,7 @@ void PicoScaledrv::picoScale_poll(){
             switch(datasrcIndex){
                 case 0:
                     aux_int64_t_prop = static_cast<int>(v.i64value);
-                    setIntegerParam(pos_ch2_longInValue, aux_int64_t_prop); 
+                    setIntegerParam(pos_ch2_longInValue, aux_int64_t_prop / scalePos2); 
                     callParamCallbacks();
                 break;
                 case 1:

--- a/picoScaleApp/src/picoScaledrv.cpp
+++ b/picoScaleApp/src/picoScaledrv.cpp
@@ -49,7 +49,7 @@ static const char *driverName = "PicoScaledriver";
 
 //------------------------------------------ AsynPortDriver ------------------------------------------
 PicoScaledrv::PicoScaledrv(const char *portName, const char *ip) 
-	: asynPortDriver(portName, MAX_SIGNALS, NUM_PARAMS,
+	: asynPortDriver(portName, MAX_SIGNALS, /*NUM_PARAMS,*/
 	asynInt32Mask | asynFloat64Mask | asynDrvUserMask,// Interfaces that we implement
 	asynInt32Mask | asynFloat64Mask,// Interfaces that do callbacks
 	ASYN_MULTIDEVICE | ASYN_CANBLOCK, 1, /* ASYN_CANBLOCK=1, ASYN_MULTIDEVICE=1, autoConnect=1 */

--- a/picoScaleApp/src/picoScaledrv.h
+++ b/picoScaleApp/src/picoScaledrv.h
@@ -1,6 +1,7 @@
 //-------------------------------- Input parameters --------------------------------
 //Channel 0 parameters
 #define pos_ch0_longInValueString		"POS_CH0_LONGIN_VAL"
+#define scalepos_ch0_longOutValueString	"SCALEPOS_CH0_LONGOUT_VAL"
 #define vel_ch0_longInValueString		"VEL_CH0_LONGIN_VAL"
 #define acc_ch0_longInValueString		"ACC_CH0_LONGIN_VAL"
 #define swraw_ch0_analogInValueString		"SWRAW_CH0_ANALOGIN_VAL"
@@ -28,6 +29,7 @@
 
 //Channel 1 parameters
 #define pos_ch1_longInValueString		"POS_CH1_LONGIN_VAL"
+#define scalepos_ch1_longOutValueString	"SCALEPOS_CH1_LONGOUT_VAL"
 #define vel_ch1_longInValueString		"VEL_CH1_LONGIN_VAL"
 #define acc_ch1_longInValueString		"ACC_CH1_LONGIN_VAL"
 #define swraw_ch1_analogInValueString		"SWRAW_CH1_ANALOGIN_VAL"
@@ -39,6 +41,7 @@
 
 //Channel 2 parameters 
 #define pos_ch2_longInValueString		"POS_CH2_LONGIN_VAL"
+#define scalepos_ch2_longOutValueString	"SCALEPOS_CH2_LONGOUT_VAL"
 #define vel_ch2_longInValueString		"VEL_CH2_LONGIN_VAL"
 #define acc_ch2_longInValueString		"ACC_CH2_LONGIN_VAL"
 #define swraw_ch2_analogInValueString		"SWRAW_CH2_ANALOGIN_VAL"
@@ -171,6 +174,7 @@ class PicoScaledrv : public asynPortDriver {
 		// --- Input parameters ---
 		//Channel 0 parameters
 		int pos_ch0_longInValue;
+		int scalepos_ch0_longOutValue;
 		int vel_ch0_longInValue;
 		int acc_ch0_longInValue;
 		int swraw_ch0_analogInValue;
@@ -198,6 +202,7 @@ class PicoScaledrv : public asynPortDriver {
 
 		//Channel 1 parameters
 		int pos_ch1_longInValue;
+		int scalepos_ch1_longOutValue;
 		int vel_ch1_longInValue;
 		int acc_ch1_longInValue;
 		int swraw_ch1_analogInValue;
@@ -209,6 +214,7 @@ class PicoScaledrv : public asynPortDriver {
 
 		//Channel 2 parameters 
 		int pos_ch2_longInValue;
+		int scalepos_ch2_longOutValue;
 		int vel_ch2_longInValue;
 		int acc_ch2_longInValue;
 		int swraw_ch2_analogInValue;


### PR DESCRIPTION
- Fixed  data-type (likely) copy-paste errors; untested, because I never need to read those properties...
- New records SCALEPOS, providing the ability to increase the measurement range of -2.1mm to +2.1mm (due to EPICS 32 bits integers limitation) by dividing the picometer values before injecting them in the POS records, while sacrificing a bit the resolution